### PR TITLE
Packing of data in CEMI frame incorrect

### DIFF
--- a/knxip/ip.py
+++ b/knxip/ip.py
@@ -204,7 +204,7 @@ class CEMIMessage():
                 (self.src_addr >> 8) & 0xff, (self.src_addr >> 0) & 0xff,
                 (self.dst_addr >> 8) & 0xff, (self.dst_addr >> 0) & 0xff,
                ]
-        if self.dptsize==0 and (len(self.data) == 1) and ((self.data[0] & 3) == self.data[0]):
+        if self.dptsize==0 and (len(self.data) == 1) and ((self.data[0] & 0xC0) == 0):
             # less than 6 bit of data, pack into APCI byte
             body.extend([1, (self.tpci_apci >> 8) & 0xff,
                          ((self.tpci_apci >> 0) & 0xff) + self.data[0]])


### PR DESCRIPTION
The way the data is packed in an CEMI frame is incorrect. The relevant line is this one in ip.py
`if (len(self.data) == 1) and ((self.data[0] & 3) == self.data[0]):`

The packing is chosen according to the data content, NOT the data type as it should be.
I admit I can't find an explicit specification in the official KNX standard but for example [this document](http://www.knx.org/fileadmin/template/documents/downloads_support_menu/KNX_tutor_seminar_page/Advanced_documentation/05_Interworking_E1209.pdf) explicitly says

> Group objects complying to DPT types with a size of 6 bits or less only use the bits directly following the APCI (any unused bits are set to zero) in the KNX telegram. Any group objects complying to DPTs with a size greater than 6 bits will result in telegrams, where the 6 bits following the APCI are set to zero and the useful data padded after these unused bits.

The problem with the current implementation is that it doesn't allow to set 1-byte object value (e.g. HVAC) to anything <4, as the devices expects a 1-byte data type which is >6 bits and should thus not be packed in the 6 bits right after the APCI.

For minimal invasive fix I recommend the first commit in the pull request that doesn't break anything but allows explicitly specifying a data type size so small values are not packed right after the APCI.

The second problem I have with this line of code is the second condition. Why does it only pack data which is 2 bits after the APCI not up to 6 bit? Ok, according to the standard, there are no 6-bit DPTs but there are two DPTs, 3.007 and 3.008, which have 4 bits and should thus be packed. This is fixed in the second commit.
However, this **might break some** (badly written) **code** that relies on setting values >3 not to be packed.