### PR TITLE
Python 2 Compatibility WIP

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,11 @@
+0.6:
+ - B/C imports of acyncio, queue and socketserver
+ - Use Queue to detect ack timeout
+ - Convert reveived bytes to bytearray
+ - Inherit DataServer from object to make super call work
+ - Comment KNXIPTunnel.conn_state_ack_semaphore, it's never used
+ - Adjust timeouts in tests
+
 0.5:
  - serialised all KNX requests to make sure the class is thread-safe
  - added delay between write requests to make sure they are sent to the bus correctly

--- a/demo/sandbox.py
+++ b/demo/sandbox.py
@@ -1,0 +1,40 @@
+from knxip.conversion import float_to_knx2
+from knxip.core import parse_group_address
+from knxip.ip import KNXIPTunnel
+import logging
+import signal
+import sys
+
+# setup global logging
+logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.DEBUG)
+
+def listener(address, data):
+    # listener callback for incoming frames
+    logging.info('Listener received: address {}, value {}'.format(address, data))
+
+# instanciate tunnel
+tunnel = KNXIPTunnel('10.0.0.76')
+
+# register listener for all incoming frames
+tunnel.notify = listener
+
+# connect tunnel
+tunnel.connect()
+
+# read group addresses
+logging.info('Read address 0/0/1: {}'.format(tunnel.group_read(parse_group_address('0/0/1'))))
+logging.info('Read address 0/0/2: {}'.format(tunnel.group_read(parse_group_address('0/0/2'))))
+
+# write group addresses
+tunnel.group_write(parse_group_address('0/0/1'), [1])
+tunnel.group_write(parse_group_address('0/0/2'), [1])
+
+# signal handler disconnecting tunnel and exit program
+def signal_handler(signal, frame):
+    logging.info('Disconnect tunnel')
+    tunnel.disconnect()
+    sys.exit(0)
+
+# wait for ctrl+c
+signal.signal(signal.SIGINT, signal_handler)
+signal.pause()

--- a/knxip/conversion.py
+++ b/knxip/conversion.py
@@ -148,3 +148,8 @@ def knx_to_datetime(knxdata):
 
     return datetime(year, month, day, hour, minute, second)
 
+
+def knx_to_group_address(ga):
+    if not isinstance(ga, int):
+        ga = struct.unpack('>H', ga)[0]
+    return '{}/{}/{}'.format((ga >> 11) & 0x1f, (ga >> 8) & 0x07, (ga) & 0xff)

--- a/knxip/gatewayscanner.py
+++ b/knxip/gatewayscanner.py
@@ -14,7 +14,10 @@ TODO:
 David Baumann(daBONDi@users.noreply.github.com)
 """
 
-import asyncio
+try:
+    import asyncio
+except ImportError:
+    import trollius as asyncio
 import logging
 import struct
 
@@ -228,7 +231,7 @@ class GatewayScanner:
             req = []
             req.extend([0x06])  # HeaderSize
             req.extend([0x10])  # KNXNetIP Version
-            req.extend([0x02, 0x01])  # Search Reques°t
+            req.extend([0x02, 0x01])  # Search Request
             req.extend([0x00, 0x0E])  # HEADER_SIZE_10 + sizeof(HPAI)
             # ==== Discovery Endpoint HPAI ====
             req.extend([0x08])  # Struct Length

--- a/knxip/ip.py
+++ b/knxip/ip.py
@@ -675,7 +675,7 @@ class DataRequestHandler(SocketServer.BaseRequestHandler):
         data = self.request[0]
         sock = self.request[1]
 
-        frame = KNXIPFrame.from_frame(data)
+        frame = KNXIPFrame.from_frame(bytearray(data))
 
         if frame.service_type_id == KNXIPFrame.TUNNELING_REQUEST:
             req = KNXTunnelingRequest.from_body(frame.body)

--- a/knxip/tests/test_conversion.py
+++ b/knxip/tests/test_conversion.py
@@ -6,7 +6,7 @@ Created on Jul 8, 2016
 import unittest
 from knxip.conversion import float_to_knx2, knx2_to_float, \
     knx_to_time, time_to_knx, knx_to_date, date_to_knx, datetime_to_knx,\
-    knx_to_datetime
+    knx_to_datetime, knx_to_group_address
 from datetime import time, date, datetime
 from knxip.core import KNXException
 
@@ -14,7 +14,7 @@ from knxip.core import KNXException
 class KNXConversionTest(unittest.TestCase):
 
     def test_float_to_knx(self):
-        """Does the float to KNX conversion works correctly?"""
+        """Does the float to KNX conversion work correctly?"""
 
         # See
         # http://www.knx.org/fileadmin/template/documents/\
@@ -28,7 +28,7 @@ class KNXConversionTest(unittest.TestCase):
         self.assertEquals(float_to_knx2(1), [0x00, 0x64])
 
     def test_knx_to_float(self):
-        """Does the KNX to float conversion works correctly?"""
+        """Does the KNX to float conversion work correctly?"""
 
         # example pg. 21/36
         self.assertEquals(knx2_to_float([0x8a, 0x24]), -30)
@@ -98,6 +98,23 @@ class KNXConversionTest(unittest.TestCase):
 
         self.assertEqual(knx_to_datetime([116, 10, 30, 238, 55, 23, 32, 128]),
                          datetime(2016, 10, 30, 14, 55, 23))
+
+    def test_knx_to_group_address(self):
+        # maximum group address is '31/7/255"
+        # in case of an overflow the value will be zero and all values left from the value will corrupt
+
+        # compute '0/0/0'
+        self.assertEqual(knx_to_group_address(0), '0/0/0')
+
+        # compute '31/7/255'
+        self.assertEqual(knx_to_group_address(65535), '31/7/255')
+
+        # compute '16/4/1'
+        self.assertEqual(knx_to_group_address(33793), '16/4/1')
+
+        # compute '16/16/1', fails due to overflow, anyway, should never happen when used only with
+        # values received from knx bus
+        self.assertEqual(knx_to_group_address(36865), '18/0/1')
 
 
 if __name__ == "__main__":

--- a/knxip/tests/test_ip.py
+++ b/knxip/tests/test_ip.py
@@ -41,17 +41,16 @@ class TestKNXIPTunnel(unittest.TestCase):
         self.assertFalse(tunnel.connected)
         tunnel.group_read(1)
         self.assertTrue(tunnel.connected)
-        
-        
+
     def testKeepAlive(self):
         """Test if the background thread runs and updated the state"""
         tunnel = KNXIPTunnel(gwip)
         self.assertTrue(tunnel.connect())
         # Background thread should reset this to 0 if the connection is still
         # alive
-        tunnel.connection_state=1
+        tunnel.connection_state = 1
         time.sleep(66)
-        self.assertEqual(tunnel.connection_state,0)        
+        self.assertEqual(tunnel.connection_state, 0)        
 
     def testReadTimeout(self):
         """Test if read timeouts work and group_read operations
@@ -66,7 +65,7 @@ class TestKNXIPTunnel(unittest.TestCase):
         res = tunnel.group_read(37000, timeout=1)
         tock = datetime.now()
         diff = tock - tick    # the result is a datetime.timedelta object
-        self.assertTrue(diff.total_seconds() >= 1 and diff.total_seconds() < 3)
+        self.assertTrue(diff.total_seconds() >= 1 and diff.total_seconds() < 3.01)
         self.assertIsNone(res)
 
         # Read from some random address and hope nothing responds here
@@ -74,7 +73,7 @@ class TestKNXIPTunnel(unittest.TestCase):
         res = tunnel.group_read(37000, timeout=5)
         tock = datetime.now()
         diff = tock - tick    # the result is a datetime.timedelta object
-        self.assertTrue(diff.total_seconds() >= 5 and diff.total_seconds() < 6)
+        self.assertTrue(diff.total_seconds() >= 5 and diff.total_seconds() < 7.01)
         self.assertIsNone(res)
 
         tunnel.disconnect()


### PR DESCRIPTION
Hi,

Thanks for this great package!

I did some changes to get it working with python 2.7. Maybe it's worth merging upstream.

Also i added a ``sandbox.py`` in demo folder demonstrating very basic operations for someone to get started.

The only module not working in python 2.7 right now is the ``gatewayscanner``. Had no time yet to dig deeper whats going wrong.

Further i was wondering what ``KNXIPTunnel.conn_state_ack_semaphore`` is good for. It's only declared but never used.

As you can see i changed the ack timeout handling from a semaphore to a queue. ``Semaphore.acquire`` does not support a timeout when called in blocking mode in python 2, while ``Queue.get`` does.
