### PR TITLE
Real cleanup if tunnel is closed. 

### DIFF
--- a/knxip/ip.py
+++ b/knxip/ip.py
@@ -405,6 +405,20 @@ class KNXIPTunnel():
         else:
             logging.debug("Disconnect - no connection, nothing to do")
 
+        # Cleanup
+        if self.data_server is not None:
+            self.data_server.shutdown()
+            self.data_server = None
+
+        self.discovery_port = None
+        self.data_port = None
+
+        self.result_queue.queue.clear()
+        self.value_cache.clear()
+        self.ack_semaphore.release()
+        self.conn_state_ack_semaphore.release()
+        self.connection_state = 0
+        self.seq = 0
         self.channel = None
         self.connected = False
 


### PR DESCRIPTION
Solves problem with frequent connect and close of tunnel.
I use this component (many thanks for it ;-)) e.g. in mycroft and weewx and there the tunnel is not open all the time but only if archive is written or a language command is invoked. Only the first connect works as expected. After close and a new connect the tunnel is not established working any more.

Feel free to contact me on gitter if you have any questions.